### PR TITLE
Implement new PHP version strategy

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -94,7 +94,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install dependencies
-        run: composer update --prefer-dist --no-progress --no-interaction --with-all-dependencies phpunit/phpunit:${{ matrix.phpunit-version }}
+        run: composer update --prefer-dist --no-progress --no-interaction --with-all-dependencies monolog/monolog psr/log wp-cli/wp-cli phpunit/phpunit:${{ matrix.phpunit-version }}
 
       - name: Run test suite
         run: vendor/bin/phpunit

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -15,14 +15,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test:
+  runtime-compat:
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        php-version: ['8.3', '8.4']
+        php-version: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
 
-    name: PHP ${{ matrix.php-version }}
+    name: Runtime PHP ${{ matrix.php-version }}
 
     runs-on: ${{ matrix.os }}
 
@@ -40,21 +40,89 @@ jobs:
 
       - name: Validate composer.json and composer.lock
         run: composer validate --strict
-        
+
+      - name: Install dependencies
+        run: composer update --prefer-dist --no-progress --no-interaction --no-dev
+
+      - name: Run runtime smoke test
+        run: composer run test:runtime-smoke
+
+  unit-tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            php-version: '7.2'
+            phpunit-version: '^8.5'
+          - os: ubuntu-latest
+            php-version: '7.3'
+            phpunit-version: '^9.6'
+          - os: ubuntu-latest
+            php-version: '7.4'
+            phpunit-version: '^9.6'
+          - os: ubuntu-latest
+            php-version: '8.0'
+            phpunit-version: '^9.6'
+          - os: ubuntu-latest
+            php-version: '8.1'
+            phpunit-version: '^9.6'
+          - os: ubuntu-latest
+            php-version: '8.2'
+            phpunit-version: '^9.6'
+          - os: ubuntu-latest
+            php-version: '8.3'
+            phpunit-version: '^12.5'
+          - os: ubuntu-latest
+            php-version: '8.4'
+            phpunit-version: '^12.5'
+
+    name: Unit PHP ${{ matrix.php-version }}
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+          tools: composer
+          coverage: none
+        env:
+          COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install dependencies
+        run: composer update --prefer-dist --no-progress --no-interaction --with-all-dependencies phpunit/phpunit:${{ matrix.phpunit-version }}
+
+      - name: Run test suite
+        run: vendor/bin/phpunit
+
+  qa-tooling:
+    name: Tooling PHP 8.3
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          tools: composer
+          coverage: none
+        env:
+          COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Install dependencies
         run: composer install --prefer-dist --no-progress --no-interaction
 
       - name: Audit dependencies
-        if: matrix.php-version == '8.3'
         run: composer audit --locked --no-interaction
-    
-      - name: Run test suite
-        run: vendor/bin/phpunit
 
       - name: Run PHPMD
-        if: matrix.php-version == '8.3'
         run: composer run lint:md
 
       - name: Run PHPCS
-        if: matrix.php-version == '8.3'
         run: composer run lint:cs

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -94,7 +94,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install dependencies
-        run: composer update --prefer-dist --no-progress --no-interaction --with-all-dependencies monolog/monolog psr/log wp-cli/wp-cli phpunit/phpunit:${{ matrix.phpunit-version }}
+        run: composer update --prefer-dist --no-progress --no-interaction --with-all-dependencies monolog/monolog psr/log wp-cli/wp-cli phpmd/phpmd pdepend/pdepend symfony/config:^5.4 symfony/finder:^5.4 phpunit/phpunit:${{ matrix.phpunit-version }}
 
       - name: Run test suite
         run: vendor/bin/phpunit

--- a/README.md
+++ b/README.md
@@ -7,8 +7,10 @@ Extension for [Monolog](https://github.com/Seldaek/monolog) that routes log outp
 
 ## Requirements
 
-- PHP 8.3+
-- Monolog 2.5
+- PHP 7.2+
+- Monolog 2.5+
+
+Current stable releases target the Monolog 2 line. Monolog 3 support remains planned for a future major release.
 
 ## Installation
 
@@ -122,7 +124,7 @@ composer run lint
 composer run qa
 ```
 
-CI runs on pull requests and pushes to main, validates Composer metadata, audits locked dependencies, runs PHPUnit on PHP 8.3 and 8.4, and runs PHPMD and PHPCS on PHP 8.3.
+CI runs on pull requests and pushes to main, validates Composer metadata, runs runtime compatibility smoke checks on PHP 7.2 through 8.4, runs PHPUnit unit tests on PHP 7.2 through 8.4 using a compatible PHPUnit line per PHP version, and runs dependency audit, PHPMD, and PHPCS on PHP 8.3.
 
 ## Testing and code quality
 

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,6 @@
   "authors": [
     {
       "name": "Mark Heydon",
-      "email": "contact@mhcg.co.uk",
       "role": "Developer"
     }
   ],

--- a/composer.json
+++ b/composer.json
@@ -18,12 +18,12 @@
   ],
   "type": "library",
   "require": {
-    "php": "^8.3",
+    "php": "^7.2 || ^8.0",
     "monolog/monolog": "^2.5"
   },
   "require-dev": {
     "wp-cli/wp-cli": "^2.12",
-    "phpunit/phpunit": "^12.5",
+    "phpunit/phpunit": "^8.5 || ^9.6 || ^12.5",
     "phpmd/phpmd": "^2.15",
     "squizlabs/php_codesniffer": "^3.11 || ^4.0"
   },
@@ -39,6 +39,7 @@
   },
   "scripts": {
     "test": "vendor/bin/phpunit",
+    "test:runtime-smoke": "php tests/runtime-smoke.php",
     "lint:md": "php -d xdebug.mode=off vendor/bin/phpmd src text codesize,unusedcode",
     "lint:cs": "vendor/bin/phpcs",
     "lint": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "541b2cffe5fa9304599263a9917ba934",
+    "content-hash": "ae81c22d65b12bf1307f83a6e9cf5c0b",
     "packages": [
         {
             "name": "monolog/monolog",
@@ -3203,7 +3203,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.3"
+        "php": "^7.2 || ^8.0"
     },
     "platform-dev": {},
     "plugin-api-version": "2.6.0"

--- a/docs-internal/php-version-strategy.md
+++ b/docs-internal/php-version-strategy.md
@@ -3,7 +3,7 @@
 ## Executive summary
 
 - Set runtime PHP support by the Monolog major targeted by the release line.
-- Do not raise `require.php` only because maintainer tooling runs on newer PHP.
+- Do not raise `composer.json` `require -> php` only because maintainer tooling runs on newer PHP.
 - If this package must require a higher PHP minimum than the targeted Monolog line, treat it as an explicit breaking policy decision and document why.
 
 ## Purpose
@@ -13,7 +13,7 @@ Define a repeatable policy for PHP support that keeps this package aligned with 
 ## Baseline principles
 
 - Monolog major compatibility is the primary driver of runtime PHP support.
-- `composer.json` `require.php` reflects consumer runtime support, not maintainer workstation defaults.
+- `composer.json` `require -> php` reflects consumer runtime support, not maintainer workstation defaults.
 - Raising minimum PHP beyond the targeted Monolog floor is a breaking policy decision and must be justified in release notes.
 
 ## Decision rules (apply in order)
@@ -64,17 +64,25 @@ Define a repeatable policy for PHP support that keeps this package aligned with 
 
 - Treat this section as process guidance, not a static snapshot.
 - For each release or branch policy update:
-  - Read current `require.php` and `monolog/monolog` constraints from `composer.json`.
+  - Read current `require -> php` and `require -> monolog/monolog` constraints from `composer.json`.
   - Map those constraints to the decision rules above.
   - Record the chosen path:
     - **Alignment path:** runtime PHP floor matches the targeted Monolog line minimum.
     - **Intentional restriction path:** runtime PHP floor is higher than Monolog minimum and rationale is documented.
 - If you include concrete constraint values in this document, add a date label and update or remove them when they are no longer current.
 
+### Current application snapshot (2026-05-16)
+
+- Active release line target: Monolog `^2.5`.
+- Chosen path: **Alignment path**.
+- Runtime policy for this line: set `require -> php` to the Monolog 2 baseline (`7.2+`) using a Composer-compatible range (for example, `^7.2 || ^8.0`) and keep tooling requirements isolated to newer PHP CI jobs.
+- CI policy for this line: run runtime compatibility checks from the declared minimum upward, and keep PHPMD/PHPCS/audit (and any newer-only tooling) on dedicated newer-PHP jobs.
+- Monolog 3 status: documented as a future major release path; not part of the current line implementation.
+
 ## Decision checklist
 
 - Which Monolog major does this release line target?
-- Does `require.php` match that Monolog major's minimum policy?
+- Does `require -> php` match that Monolog major's minimum policy?
 - If stricter, is the reason explicit, valid, and documented?
 - Is the change breaking, and is release versioning aligned?
 - Does CI distinguish runtime minimum validation from tooling convenience jobs?

--- a/docs-internal/readme-and-badges.md
+++ b/docs-internal/readme-and-badges.md
@@ -27,3 +27,4 @@ Current policy:
 - Preserve the install command for the current package identity.
 - Preserve representative usage examples unless code/tests indicate they are outdated.
 - Avoid adding sections that do not reflect real repository artefacts.
+- Keep requirements and CI wording aligned with `composer.json` and `.github/workflows/php.yml`, including explicit distinction between runtime compatibility jobs and newer-PHP tooling jobs.

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -7,6 +7,7 @@
 
   <file>src</file>
   <file>tests</file>
+  <exclude-pattern>tests/runtime-smoke.php</exclude-pattern>
 
   <rule ref="PSR12"/>
 </ruleset>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" colors="true" stopOnFailure="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.5/phpunit.xsd" cacheDirectory=".phpunit.cache">
+<phpunit bootstrap="vendor/autoload.php" colors="true" stopOnFailure="true">
   <testsuites>
     <testsuite name="Unit Tests">
       <directory suffix="Test.php">./tests</directory>
@@ -8,9 +8,4 @@
   <php>
     <ini name="date.timezone" value="UTC"/>
   </php>
-  <source>
-    <include>
-      <directory suffix=".php">./src</directory>
-    </include>
-  </source>
 </phpunit>

--- a/tests/Monolog/Handler/WPCLIHandlerTest.php
+++ b/tests/Monolog/Handler/WPCLIHandlerTest.php
@@ -217,8 +217,12 @@ class WPCLIHandlerTest extends TestCase
     public function testValidateLoggerMapInvalidLevel()
     {
         $defaultMap = WPCLIHandler::getDefaultLoggerMap();
-        $this->expectExceptionMessageMatches('/has no entry for level/');
-        WPCLIHandler::validateLoggerMap($defaultMap, 999999, 'Whatever');
+        try {
+            WPCLIHandler::validateLoggerMap($defaultMap, 999999, 'Whatever');
+            $this->fail('Expected InvalidArgumentException was not thrown.');
+        } catch (\InvalidArgumentException $e) {
+            $this->assertStringContainsString('has no entry for level', $e->getMessage());
+        }
     }
 
     /**
@@ -231,8 +235,12 @@ class WPCLIHandlerTest extends TestCase
                 'method' => 'method_does_not_exist'
             ]
         ];
-        $this->expectExceptionMessageMatches('/invalid method/');
-        WPCLIHandler::validateLoggerMap($map, 999999, 'Whatever');
+        try {
+            WPCLIHandler::validateLoggerMap($map, 999999, 'Whatever');
+            $this->fail('Expected InvalidArgumentException was not thrown.');
+        } catch (\InvalidArgumentException $e) {
+            $this->assertStringContainsString('invalid method', $e->getMessage());
+        }
     }
 
     /**
@@ -246,12 +254,16 @@ class WPCLIHandlerTest extends TestCase
                 'exit' => true
             ]
         ];
-        $this->expectExceptionMessageMatches('/specifies exit/');
-        WPCLIHandler::validateLoggerMap(
-            $map,
-            Logger::DEBUG,
-            Logger::getLevelName(Logger::DEBUG)
-        );
+        try {
+            WPCLIHandler::validateLoggerMap(
+                $map,
+                Logger::DEBUG,
+                Logger::getLevelName(Logger::DEBUG)
+            );
+            $this->fail('Expected InvalidArgumentException was not thrown.');
+        } catch (\InvalidArgumentException $e) {
+            $this->assertStringContainsString('specifies exit', $e->getMessage());
+        }
     }
 
     /**

--- a/tests/runtime-smoke.php
+++ b/tests/runtime-smoke.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+use MHCG\Monolog\Handler\WPCLIHandler;
+use Monolog\Logger;
+
+if (!defined('WP_CLI')) {
+    define('WP_CLI', true);
+}
+
+if (!class_exists('WP_CLI', false)) {
+    class WP_CLI
+    {
+        public static function debug($message): void
+        {
+        }
+
+        public static function log($message): void
+        {
+        }
+
+        public static function warning($message): void
+        {
+        }
+
+        public static function error($message, $exit = false): void
+        {
+        }
+    }
+}
+
+require __DIR__ . '/../vendor/autoload.php';
+
+$handler = new WPCLIHandler(Logger::DEBUG);
+$logger = new Logger('runtime-smoke');
+$logger->pushHandler($handler);
+$logger->info('runtime smoke test');
+
+echo "runtime-smoke-ok\n";


### PR DESCRIPTION
This pull request updates the PHP version strategy to support versions 7.2 through 8.4, ensuring compatibility with the Monolog library. It enhances the CI process by adding runtime compatibility smoke tests and adjusting PHPUnit versions accordingly. No specific issue is referenced.

