### PR TITLE
Clarify and test verbose context handling in WPCLIHandler

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,18 +5,18 @@
 
 Extension for [Monolog](https://github.com/Seldaek/monolog) that routes log output through WP-CLI when running `wp` commands.
 
+## Installation
+
+```shell
+composer require mhcg/monolog-wp-cli
+```
+
 ## Requirements
 
 - PHP `^7.2 || ^8.0`
 - monolog/monolog `^2.5`
 
 Current stable releases target the Monolog 2 line. Monolog 3 support remains planned for a future major release.
-
-## Installation
-
-```shell
-composer require mhcg/monolog-wp-cli
-```
 
 ## Usage
 
@@ -162,18 +162,6 @@ composer run lint
 composer run qa
 ```
 
-Composer script quick reference:
-
-- `test`: run PHPUnit tests.
-- `test:runtime-smoke`: run fast runtime contract smoke checks.
-- `wp:env:up`: start local WordPress integration containers.
-- `test:wp:setup`: bootstrap WordPress and activate fixture plugin.
-- `test:wp:smoke`: run WP-CLI integration smoke checks.
-- `test:wp`: run `wp:env:up`, `test:wp:setup`, and `test:wp:smoke`.
-- `wp:env:down`: stop integration containers and remove volumes.
-- `lint`: run PHPMD and PHPCS.
-- `qa`: run PHPUnit plus lint checks.
-
 Run WordPress integration checks step-by-step:
 
 ```shell
@@ -185,7 +173,10 @@ composer run wp:env:down
 
 Note: `composer run test:wp` does not call `wp:env:down`; run teardown explicitly when you are finished.
 
-CI runs on pull requests and pushes to main. The PHP workflow validates Composer metadata, runs runtime compatibility smoke checks on PHP 7.2 through 8.4, runs PHPUnit unit tests on PHP 7.2 through 8.4 using a compatible PHPUnit line per PHP version, and runs dependency audit, PHPMD, and PHPCS on PHP 8.3. A separate WordPress integration workflow provisions WordPress with WP-CLI and runs the integration smoke checks.
+CI runs on pull requests and pushes to `main`.
+
+- `PHP CI` validates Composer metadata, runs runtime smoke checks on PHP 7.2 to 8.4, runs unit tests across PHP 7.2 to 8.4 using a compatible PHPUnit line per PHP version, and runs dependency audit, PHPMD, and PHPCS on PHP 8.3.
+- `WordPress Integration` provisions WordPress with WP-CLI and runs the integration smoke checks.
 
 ## Testing and code quality
 
@@ -199,7 +190,7 @@ Fork the repository and open a pull request for code changes, referencing the re
 
 Documentation improvements are also welcome through the project wiki.
 
-Please follow the [Code of Conduct](https://github.com/markheydon/monolog-wp-cli/blob/main/.github/CODE_OF_CONDUCT.md).
+Please follow the [Code of Conduct](.github/CODE_OF_CONDUCT.md).
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ composer require mhcg/monolog-wp-cli
 
 `WPCLIHandler` works like any other Monolog handler. Create the handler and push it onto a logger inside a WP-CLI command context.
 
+By default the handler uses message-only output. Monolog `context` and `extra` data are only rendered when verbose formatting is enabled, either by passing `true` as the third `WPCLIHandler` constructor argument or when `WP_DEBUG` is enabled.
+
 ### Version note (v2.2)
 
 From v2.2, default `NOTICE` handling changed from `WP_CLI::warning()` to `WP_CLI::log()`.
@@ -63,6 +65,13 @@ $log->error('An error has occurred');
 $log->critical('This will report error and exit out');
 $log->debug('Only shown when running wp with --debug');
 $log->info('General logging - will not be shown when running wp with --quiet');
+```
+
+If you want Monolog `context` and `extra` data included in the output, enable verbose formatting:
+
+```php
+$log->pushHandler(new WPCLIHandler(Logger::WARNING, true, true));
+$log->warning('This includes context in verbose mode', ['job' => 'import']);
 ```
 
 ### WordPress plugin-style example

--- a/docs/how-to/use-wpclihandler-in-a-command.md
+++ b/docs/how-to/use-wpclihandler-in-a-command.md
@@ -70,5 +70,6 @@ wp mycommand --quiet
 
 - The handler is intended for WP-CLI runtime. Constructing it outside WP-CLI raises a runtime exception.
 - `debug` messages rely on WP-CLI debug mode.
+- Monolog `context` and `extra` data are only shown when the handler is in verbose mode, either via the constructor flag or `WP_DEBUG`.
 - From v2.2, `notice` maps to `WP_CLI::log()` by default.
 - Error-level output is sent through WP-CLI error handling.

--- a/docs/how-to/use-wpclihandler-in-a-command.md
+++ b/docs/how-to/use-wpclihandler-in-a-command.md
@@ -48,19 +48,28 @@ $logger->pushHandler(
 );
 ```
 
-4. Run the command normally:
+4. Optional: if you want Monolog `context` and `extra` data in output, enable verbose mode:
+
+```php
+$logger->pushHandler( new WPCLIHandler( Logger::INFO, true, true ) );
+$logger->notice( 'Processed batch', [ 'batch' => 12 ] );
+```
+
+You can also enable the same formatter behaviour through `WP_DEBUG`.
+
+5. Run the command normally:
 
 ```shell
 wp mycommand
 ```
 
-5. Optional: run with debug visibility:
+6. Optional: run with debug visibility:
 
 ```shell
 wp mycommand --debug
 ```
 
-6. Optional: run in quiet mode:
+7. Optional: run in quiet mode:
 
 ```shell
 wp mycommand --quiet

--- a/docs/reference/wpclihandler.md
+++ b/docs/reference/wpclihandler.md
@@ -41,6 +41,8 @@ Each map entry uses this shape:
 - Standard format: `%message%`
 - Verbose format: `%message% %context% %extra%`
 
+That means Monolog `context` and `extra` data are not shown in standard output. They are only rendered when verbose output is enabled.
+
 Verbose output is enabled when either:
 
 - `WP_DEBUG` is enabled, or

--- a/docs/reference/wpclihandler.md
+++ b/docs/reference/wpclihandler.md
@@ -48,6 +48,14 @@ Verbose output is enabled when either:
 - `WP_DEBUG` is enabled, or
 - constructor `$verbose` is `true`
 
+Example verbose output from the WordPress integration smoke fixture:
+
+```text
+(NOTICE) context from wp {"foo":"bar"} []
+```
+
+In this output shape, the trailing `[]` is Monolog `extra` data when no extra keys are present.
+
 ## Default Monolog-to-WP-CLI mapping
 
 | Monolog level | WP-CLI method | includeLevelName | exit |

--- a/docs/tutorials/first-logger-in-wp-cli.md
+++ b/docs/tutorials/first-logger-in-wp-cli.md
@@ -63,6 +63,17 @@ Expected behaviour:
 - Normal output is suppressed.
 - Error output still appears.
 
+## 5. Enable context output when needed
+
+By default, output uses message-only formatting. To include Monolog `context` and `extra` data, enable verbose mode:
+
+```php
+$log->pushHandler( new WPCLIHandler( Logger::INFO, true, true ) );
+$log->notice( 'Import completed', [ 'items' => 5 ] );
+```
+
+You can also enable verbose output by setting `WP_DEBUG` to true in the runtime.
+
 ## Next step
 
 If you already have an existing command and only need integration steps, continue with the [how-to guide](../how-to/use-wpclihandler-in-a-command.md).

--- a/tests/Monolog/Handler/WPCLIHandlerTest.php
+++ b/tests/Monolog/Handler/WPCLIHandlerTest.php
@@ -212,32 +212,79 @@ class WPCLIHandlerTest extends TestCase
     }
 
     /**
-     * Tests the formatter is different between standard and verbose
+     * Tests standard formatter keeps output to the message only.
      *
      * @covers \MHCG\Monolog\Handler\WPCLIHandler::getFormatter
      */
-    public function testFormatterDifferent()
+    public function testStandardFormatterOutputsMessageOnly()
     {
         $this->sanityCheck();
 
         $this->pretendToBeInWPCLI();
         $standard = new WPCLIHandler(Logger::DEBUG, true, false);
+        $testRecord = array(
+            'message' => 'This is a message',
+            'context' => array('whatever' => 'something'),
+            'extra' => array('whatever2' => 'something else'),
+        );
+
+        $testStandard = $standard->getFormatter()->format($testRecord);
+
+        $this->assertSame('This is a message', trim($testStandard));
+    }
+
+    /**
+     * Tests verbose formatter includes serialized context and extra data.
+     *
+     * @covers \MHCG\Monolog\Handler\WPCLIHandler::getFormatter
+     */
+    public function testVerboseFormatterIncludesContextAndExtra()
+    {
+        $this->sanityCheck();
+
+        $this->pretendToBeInWPCLI();
         $verbose = new WPCLIHandler(Logger::DEBUG, true, true);
         $testRecord = array(
             'message' => 'This is a message',
             'context' => array('whatever' => 'something'),
-            'extra' => array('whatever2' => 'someting else')
+            'extra' => array('whatever2' => 'something else'),
         );
 
-        $testStandard = $standard->getFormatter()->format($testRecord);
         $testVerbose = $verbose->getFormatter()->format($testRecord);
 
-        // test there is something in both
-        $this->assertTrue(strlen($testStandard) > 1);
-        $this->assertTrue(strlen($testVerbose) > 1);
+        $this->assertSame(
+            'This is a message {"whatever":"something"} {"whatever2":"something else"}',
+            trim($testVerbose)
+        );
+    }
 
-        // then test they are different (which they should be)
-        $this->assertNotEquals($testStandard, $testVerbose);
+    /**
+     * Tests WP_DEBUG enables verbose formatter output even when constructor verbose is false.
+     *
+     * @covers \MHCG\Monolog\Handler\WPCLIHandler::__construct
+     * @covers \MHCG\Monolog\Handler\WPCLIHandler::getFormatter
+     * @runInSeparateProcess
+     */
+    public function testWpDebugEnablesVerboseFormatterOutput()
+    {
+        $this->sanityCheck();
+
+        $this->pretendToBeInWPCLI();
+        define('WP_DEBUG', true);
+
+        $handler = new WPCLIHandler(Logger::DEBUG, true, false);
+        $testRecord = array(
+            'message' => 'This is a message',
+            'context' => array('whatever' => 'something'),
+            'extra' => array('whatever2' => 'something else'),
+        );
+
+        $formatted = $handler->getFormatter()->format($testRecord);
+
+        $this->assertSame(
+            'This is a message {"whatever":"something"} {"whatever2":"something else"}',
+            trim($formatted)
+        );
     }
 
     //</editor-fold>

--- a/tests/wordpress/bin/run-smoke.sh
+++ b/tests/wordpress/bin/run-smoke.sh
@@ -48,4 +48,7 @@ fi
 DEBUG_OUTPUT="$("${WP[@]}" --debug monolog-smoke --level=debug --message='debug from wp' 2>&1)"
 assert_contains "debug from wp" "$DEBUG_OUTPUT" "DEBUG output should be visible with --debug."
 
+VERBOSE_CONTEXT_OUTPUT="$(${WP[@]} monolog-smoke --level=notice --message='context from wp' --handler-verbose=1 --context-key=foo --context-value=bar 2>&1)"
+assert_contains '(NOTICE) context from wp {"foo":"bar"} []' "$VERBOSE_CONTEXT_OUTPUT" "Verbose handler output should include serialized context data."
+
 echo "wp-smoke-ok"

--- a/tests/wordpress/fixtures/monolog-wp-cli-smoke/monolog-wp-cli-smoke.php
+++ b/tests/wordpress/fixtures/monolog-wp-cli-smoke/monolog-wp-cli-smoke.php
@@ -23,28 +23,38 @@ if (!class_exists('MHCG\\Monolog\\Handler\\WPCLIHandler')) {
 WP_CLI::add_command('monolog-smoke', static function (array $args, array $assocArgs): void {
     $level = isset($assocArgs['level']) ? (string) $assocArgs['level'] : 'notice';
     $message = isset($assocArgs['message']) ? (string) $assocArgs['message'] : 'smoke';
+    $handlerVerbose = !empty($assocArgs['handler-verbose']);
+    $context = [];
+
+    if (isset($assocArgs['context-key'])) {
+        $context[(string) $assocArgs['context-key']] = isset($assocArgs['context-value'])
+            ? (string) $assocArgs['context-value']
+            : '';
+    }
 
     $logger = new \Monolog\Logger('monolog-smoke');
-    $logger->pushHandler(new \MHCG\Monolog\Handler\WPCLIHandler(\Monolog\Logger::DEBUG));
+    $logger->pushHandler(
+        new \MHCG\Monolog\Handler\WPCLIHandler(\Monolog\Logger::DEBUG, true, $handlerVerbose)
+    );
 
     switch ($level) {
         case 'debug':
-            $logger->debug($message);
+            $logger->debug($message, $context);
             break;
         case 'info':
-            $logger->info($message);
+            $logger->info($message, $context);
             break;
         case 'notice':
-            $logger->notice($message);
+            $logger->notice($message, $context);
             break;
         case 'warning':
-            $logger->warning($message);
+            $logger->warning($message, $context);
             break;
         case 'error':
-            $logger->error($message);
+            $logger->error($message, $context);
             break;
         case 'critical':
-            $logger->critical($message);
+            $logger->critical($message, $context);
             break;
         default:
             WP_CLI::error('Unsupported level: ' . $level, 2);


### PR DESCRIPTION
## Summary
- add explicit unit coverage for formatter output in standard vs verbose mode
- add explicit unit coverage proving `WP_DEBUG=true` enables verbose formatter output
- extend WordPress smoke fixture and smoke script to assert context output in verbose mode
- clarify public docs that context and extra are rendered only in verbose output

## Validation
- vendor/bin/phpunit tests/Monolog/Handler/WPCLIHandlerTest.php
- composer run test:wp
- composer run qa

Closes #18